### PR TITLE
Better support for netstandard

### DIFF
--- a/Client/package.nuspec
+++ b/Client/package.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Pathoschild.Http.FluentClient</id>
-    <version>2.3.0</version>
+    <version>2.4.0</version>
     <authors>Jesse Plamondon-Willard</authors>
     <description>An easy asynchronous HTTP client for REST APIs. It provides a fluent interface that lets you create an HTTP request, dispatch and wait for it, and parse the response.</description>
     <licenseUrl>https://creativecommons.org/licenses/by/3.0/</licenseUrl>
@@ -11,13 +11,24 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>wcf web webapi httpclient</tags>
     <dependencies>
-      <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2" />
-      <dependency id="System.Net.Http" version="4.1.0" />
+      <group targetFramework="net452">
+        <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.3" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
+        <dependency id="System.Net.Http" version="4.0.0" />
+      </group>
+      <group targetFramework=".NETStandard1.3">
+        <dependency id="WinInsider.System.Net.Http.Formatting" version="1.0.1" />
+        <dependency id="NETStandard.Library" version="1.6.1" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
+        <dependency id="System.Net.Http" version="4.3.0" />
+      </group>
     </dependencies>
     <releaseNotes>Migrated to .NET Standard.</releaseNotes>
   </metadata>
   <files>
-    <file src="bin\Release\netstandard1.1\Pathoschild.Http.Client.dll" target="lib\netstandard1.1\" />
-    <file src="bin\Release\netstandard1.1\Pathoschild.Http.Client.xml" target="lib\netstandard1.1\" />
+    <file src="bin\Release\net452\Pathoschild.Http.Client.dll" target="lib\net452\" />
+    <file src="bin\Release\net452\Pathoschild.Http.Client.xml" target="lib\net452\" />
+    <file src="bin\Release\netstandard1.3\Pathoschild.Http.Client.dll" target="lib\netstandard1.1\" />
+    <file src="bin\Release\netstandard1.3\Pathoschild.Http.Client.xml" target="lib\netstandard1.1\" />
   </files>
 </package>

--- a/Client/project.json
+++ b/Client/project.json
@@ -1,15 +1,32 @@
 {
   "supports": {},
   "dependencies": {
-    "Microsoft.AspNet.WebApi.Client": "5.2.3",
-    "Newtonsoft.Json": "9.0.1",
-    "System.Net.Http": "4.1.0",
-    "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.1"
+    "Newtonsoft.Json": "9.0.1"
   },
   "frameworks": {
-    "netstandard1.1": {
-      "imports": "portable-net45+win8" // needed for Microsoft.AspNet.WebApi.Client
+    "netstandard1.3": {
+      "imports": [
+        "dnxcore50"
+      ],
+      "dependencies": {
+        "NETStandard.Library": "1.6.1",
+        "System.Net.Http": "4.3.0",
+        "WinInsider.System.Net.Http.Formatting": "1.0.1"
+      }
+    },
+    "net452": {
+      "buildOptions": {
+        "define": [ "NET452" ]
+      },
+      "dependencies": {
+        "Microsoft.AspNet.WebApi.Client": "5.2.3",
+        "System.Net.Http": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": {
+          "type": "build"
+        }
+      }
     }
   },
   "buildOptions": {

--- a/Tests/project.json
+++ b/Tests/project.json
@@ -1,20 +1,36 @@
 {
+  "testRunner": "nunit",
+
   "dependencies": {
-    "Client": "*",
-    "Microsoft.AspNet.WebApi.Client": "5.2.3",
+    "Client": { "target": "project" },
+    "dotnet-test-nunit": "3.4.0-beta-3",
     "Microsoft.AspNet.WebUtilities": "1.0.0-rc1-final",
-    "Moq": "4.5.10",
-    "NETStandard.Library": "1.6.0",
+    "Moq": "4.6.38-alpha",
+    "NETStandard.Library": "1.6.1",
     "Newtonsoft.Json": "9.0.1",
-    "NUnit": "3.4.0"
+    "NUnit": "3.5.0"
   },
+
   "frameworks": {
-    "netstandard1.6": {
+    "netcoreapp1.0": {
       "imports": [
-        "dnxcore50",          // needed for Microsoft.AspNet.WebUtilities
-        "net45",              // needed for Moq
-        "portable-net45+win8" // needed for Microsoft.AspNet.WebApi.Client
-      ]
+        "dnxcore50"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.1"
+        }
+      }
+    },
+    "net452": {
+      "dependencies": {
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": {
+          "type": "build"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
- Configure project.json to target net452 and netstandard1.3
- Reference WinInsider.System.Net.Http.Formatting in netstandard1.3 and Microsoft.AspNet.WebApi.Client in net452 (due to the fact that Microsoft's package is not compatible with netstandard)
- Configure nuspec to bundle both version of this library

#7 