### PR TITLE
Fix path in nuspec

### DIFF
--- a/Client/package.nuspec
+++ b/Client/package.nuspec
@@ -28,7 +28,7 @@
   <files>
     <file src="bin\Release\net452\Pathoschild.Http.Client.dll" target="lib\net452\" />
     <file src="bin\Release\net452\Pathoschild.Http.Client.xml" target="lib\net452\" />
-    <file src="bin\Release\netstandard1.3\Pathoschild.Http.Client.dll" target="lib\netstandard1.1\" />
-    <file src="bin\Release\netstandard1.3\Pathoschild.Http.Client.xml" target="lib\netstandard1.1\" />
+    <file src="bin\Release\netstandard1.3\Pathoschild.Http.Client.dll" target="lib\netstandard1.3\" />
+    <file src="bin\Release\netstandard1.3\Pathoschild.Http.Client.xml" target="lib\netstandard1.3\" />
   </files>
 </package>


### PR DESCRIPTION
The target path in nuspec incorrectly point to `netstandard1.1` when it should be `netstandard1.3`