### PR TITLE
Authentication

### DIFF
--- a/Client/FluentClient.cs
+++ b/Client/FluentClient.cs
@@ -88,17 +88,19 @@ namespace Pathoschild.Http.Client
         /// <summary>Specify the authentication that will be used with every request.</summary>
         /// <param name="scheme">The scheme to use for authorization. e.g.: "Basic", "Bearer".</param>
         /// <param name="parameter">The credentials containing the authentication information.</param>
-        public void SetAuthentication(string scheme, string parameter)
+        public IClient SetAuthentication(string scheme, string parameter)
         {
             this.BaseClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(scheme, parameter);
+            return this;
         }
 
         /// <summary>Set the default user agent header.</summary>
         /// <param name="userAgent">The user agent header value.</param>
-        public void SetUserAgent(string userAgent)
+        public IClient SetUserAgent(string userAgent)
         {
             this.BaseClient.DefaultRequestHeaders.Remove("User-Agent");
             this.BaseClient.DefaultRequestHeaders.Add("User-Agent", userAgent);
+            return this;
         }
 
         /// <summary>Free resources used by the client.</summary>

--- a/Client/FluentClient.cs
+++ b/Client/FluentClient.cs
@@ -101,14 +101,6 @@ namespace Pathoschild.Http.Client
             this.BaseClient.DefaultRequestHeaders.Add("User-Agent", userAgent);
         }
 
-        /// <summary>Specify the authentication that will be used with every request.</summary>
-        /// <param name="scheme">The scheme to use for authorization. e.g.: "Basic", "Bearer".</param>
-        /// <param name="parameter">The credentials containing the authentication information.</param>
-        public void SetAuthentication(string scheme, string parameter)
-        {
-            this.BaseClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(scheme, parameter);
-        }
-
         /// <summary>Free resources used by the client.</summary>
         public virtual void Dispose()
         {

--- a/Client/FluentClient.cs
+++ b/Client/FluentClient.cs
@@ -96,7 +96,7 @@ namespace Pathoschild.Http.Client
         /// <summary>Specify the authentication that will be used with every request.</summary>
         /// <param name="scheme">The scheme to use for authorization. e.g.: "Basic", "Bearer".</param>
         /// <param name="parameter">The credentials containing the authentication information.</param>
-        public void AddAuthentication(string scheme, string parameter)
+        public void SetAuthentication(string scheme, string parameter)
         {
             this.BaseClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(scheme, parameter);
         }

--- a/Client/FluentClient.cs
+++ b/Client/FluentClient.cs
@@ -88,7 +88,7 @@ namespace Pathoschild.Http.Client
         /// <summary>Specify the authentication that will be used with every request.</summary>
         /// <param name="scheme">The scheme to use for authorization. e.g.: "Basic", "Bearer".</param>
         /// <param name="parameter">The credentials containing the authentication information.</param>
-        public void AddAuthentication(string scheme, string parameter)
+        public void SetAuthentication(string scheme, string parameter)
         {
             this.BaseClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(scheme, parameter);
         }

--- a/Client/FluentClient.cs
+++ b/Client/FluentClient.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Formatting;
 using System.Reflection;
 using Pathoschild.Http.Client.Extensibility;
 using Pathoschild.Http.Client.Internal;
+using System.Net.Http.Headers;
 
 namespace Pathoschild.Http.Client
 {
@@ -90,6 +91,14 @@ namespace Pathoschild.Http.Client
         {
             this.BaseClient.DefaultRequestHeaders.Remove("User-Agent");
             this.BaseClient.DefaultRequestHeaders.Add("User-Agent", userAgent);
+        }
+
+        /// <summary>Specify the authentication that will be used with every request.</summary>
+        /// <param name="scheme">The scheme to use for authorization. e.g.: "Basic", "Bearer".</param>
+        /// <param name="parameter">The credentials containing the authentication information.</param>
+        public void AddAuthentication(string scheme, string parameter)
+        {
+            this.BaseClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(scheme, parameter);
         }
 
         /// <summary>Free resources used by the client.</summary>

--- a/Client/FluentClient.cs
+++ b/Client/FluentClient.cs
@@ -85,6 +85,14 @@ namespace Pathoschild.Http.Client
             return new Request(message, this.Formatters, request => this.BaseClient.SendAsync(request.Message), this.Filters.ToArray());
         }
 
+        /// <summary>Specify the authentication that will be used with every request.</summary>
+        /// <param name="scheme">The scheme to use for authorization. e.g.: "Basic", "Bearer".</param>
+        /// <param name="parameter">The credentials containing the authentication information.</param>
+        public void AddAuthentication(string scheme, string parameter)
+        {
+            this.BaseClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(scheme, parameter);
+        }
+
         /// <summary>Set the default user agent header.</summary>
         /// <param name="userAgent">The user agent header value.</param>
         public void SetUserAgent(string userAgent)

--- a/Client/FluentClientExtensions.cs
+++ b/Client/FluentClientExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using Pathoschild.Http.Client.Extensibility;
 using Pathoschild.Http.Client.Internal;
 
@@ -97,6 +98,23 @@ namespace Pathoschild.Http.Client
             var uri = new Uri(client.BaseClient.BaseAddress, resource);
             var message = Factory.GetRequestMessage(method, uri, client.Formatters);
             return client.SendAsync(message);
+        }
+
+        /// <summary>Use basic authentication with every request.</summary>
+        /// <param name="client">The client.</param>
+        /// <param name="username">The username.</param>
+        /// <param name="password">The password.</param>
+        public static void AddBasicAuthentication(this IClient client, string username, string password)
+        {
+            client.AddAuthentication("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Concat(username, ":", password))));
+        }
+
+        /// <summary>Use 'Bearer' authentication with every request.</summary>
+        /// <param name="client">The client.</param>
+        /// <param name="key">The bearer key (typically, this is an API key).</param>
+        public static void AddBearerAuthentication(this IClient client, string key)
+        {
+            client.AddAuthentication("Bearer", key);
         }
     }
 }

--- a/Client/FluentClientExtensions.cs
+++ b/Client/FluentClientExtensions.cs
@@ -116,5 +116,22 @@ namespace Pathoschild.Http.Client
         {
             client.AddAuthentication("Bearer", key);
         }
+
+        /// <summary>Use basic authentication with this request.</summary>
+        /// <param name="request">The request.</param>
+        /// <param name="username">The username.</param>
+        /// <param name="password">The password.</param>
+        public static IRequest WithBasicAuthentication(this IRequest request, string username, string password)
+        {
+            return request.WithAuthentication("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Concat(username, ":", password))));
+        }
+
+        /// <summary>Use 'Bearer' authentication with this request.</summary>
+        /// <param name="request">The request.</param>
+        /// <param name="key">The bearer key (typically, this is an API key).</param>
+        public static IRequest WithBearerAuthentication(this IRequest request, string key)
+        {
+            return request.WithAuthentication("Bearer", key);
+        }
     }
 }

--- a/Client/FluentClientExtensions.cs
+++ b/Client/FluentClientExtensions.cs
@@ -104,17 +104,17 @@ namespace Pathoschild.Http.Client
         /// <param name="client">The client.</param>
         /// <param name="username">The username.</param>
         /// <param name="password">The password.</param>
-        public static void AddBasicAuthentication(this IClient client, string username, string password)
+        public static void SetBasicAuthentication(this IClient client, string username, string password)
         {
-            client.AddAuthentication("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Concat(username, ":", password))));
+            client.SetAuthentication("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Concat(username, ":", password))));
         }
 
         /// <summary>Use 'Bearer' authentication with every request.</summary>
         /// <param name="client">The client.</param>
         /// <param name="key">The bearer key (typically, this is an API key).</param>
-        public static void AddBearerAuthentication(this IClient client, string key)
+        public static void SetBearerAuthentication(this IClient client, string key)
         {
-            client.AddAuthentication("Bearer", key);
+            client.SetAuthentication("Bearer", key);
         }
 
         /// <summary>Use basic authentication with this request.</summary>

--- a/Client/FluentClientExtensions.cs
+++ b/Client/FluentClientExtensions.cs
@@ -100,40 +100,6 @@ namespace Pathoschild.Http.Client
             return client.SendAsync(message);
         }
 
-        /// <summary>Use basic authentication with every request.</summary>
-        /// <param name="client">The client.</param>
-        /// <param name="username">The username.</param>
-        /// <param name="password">The password.</param>
-        public static void SetBasicAuthentication(this IClient client, string username, string password)
-        {
-            client.SetAuthentication("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Concat(username, ":", password))));
-        }
-
-        /// <summary>Use 'Bearer' authentication with every request.</summary>
-        /// <param name="client">The client.</param>
-        /// <param name="key">The bearer key (typically, this is an API key).</param>
-        public static void SetBearerAuthentication(this IClient client, string key)
-        {
-            client.SetAuthentication("Bearer", key);
-        }
-
-        /// <summary>Use basic authentication with this request.</summary>
-        /// <param name="request">The request.</param>
-        /// <param name="username">The username.</param>
-        /// <param name="password">The password.</param>
-        public static IRequest WithBasicAuthentication(this IRequest request, string username, string password)
-        {
-            return request.WithAuthentication("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Concat(username, ":", password))));
-        }
-
-        /// <summary>Use 'Bearer' authentication with this request.</summary>
-        /// <param name="request">The request.</param>
-        /// <param name="key">The bearer key (typically, this is an API key).</param>
-        public static IRequest WithBearerAuthentication(this IRequest request, string key)
-        {
-            return request.WithAuthentication("Bearer", key);
-        }
-
         /// <summary>Use basic authentication with this request.</summary>
         /// <param name="request">The request.</param>
         /// <param name="username">The username.</param>

--- a/Client/FluentClientExtensions.cs
+++ b/Client/FluentClientExtensions.cs
@@ -133,5 +133,22 @@ namespace Pathoschild.Http.Client
         {
             return request.WithAuthentication("Bearer", key);
         }
+
+        /// <summary>Use basic authentication with this request.</summary>
+        /// <param name="request">The request.</param>
+        /// <param name="username">The username.</param>
+        /// <param name="password">The password.</param>
+        public static IRequest WithBasicAuthentication(this IRequest request, string username, string password)
+        {
+            return request.WithAuthentication("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Concat(username, ":", password))));
+        }
+
+        /// <summary>Use 'Bearer' authentication with this request.</summary>
+        /// <param name="request">The request.</param>
+        /// <param name="key">The bearer key (typically, this is an API key).</param>
+        public static IRequest WithBearerAuthentication(this IRequest request, string key)
+        {
+            return request.WithAuthentication("Bearer", key);
+        }
     }
 }

--- a/Client/IClient.cs
+++ b/Client/IClient.cs
@@ -33,10 +33,5 @@ namespace Pathoschild.Http.Client
         /// <summary>Set the default user agent header.</summary>
         /// <param name="userAgent">The user agent header value.</param>
         void SetUserAgent(string userAgent);
-
-        /// <summary>Specify the authentication that will be used with every request.</summary>
-        /// <param name="scheme">The scheme to use for authorization. e.g.: "Basic", "Bearer".</param>
-        /// <param name="parameter">The credentials containing the authentication information.</param>
-        void SetAuthentication(string scheme, string parameter);
     }
 }

--- a/Client/IClient.cs
+++ b/Client/IClient.cs
@@ -28,7 +28,7 @@ namespace Pathoschild.Http.Client
         /// <summary>Specify the authentication that will be used with every request.</summary>
         /// <param name="scheme">The scheme to use for authorization. e.g.: "Basic", "Bearer".</param>
         /// <param name="parameter">The credentials containing the authentication information.</param>
-        void AddAuthentication(string scheme, string parameter);
+        void SetAuthentication(string scheme, string parameter);
 
         /// <summary>Set the default user agent header.</summary>
         /// <param name="userAgent">The user agent header value.</param>

--- a/Client/IClient.cs
+++ b/Client/IClient.cs
@@ -28,5 +28,10 @@ namespace Pathoschild.Http.Client
         /// <summary>Set the default user agent header.</summary>
         /// <param name="userAgent">The user agent header value.</param>
         void SetUserAgent(string userAgent);
+
+        /// <summary>Specify the authentication that will be used with every request.</summary>
+        /// <param name="scheme">The scheme to use for authorization. e.g.: "Basic", "Bearer".</param>
+        /// <param name="parameter">The credentials containing the authentication information.</param>
+        void AddAuthentication(string scheme, string parameter);
     }
 }

--- a/Client/IClient.cs
+++ b/Client/IClient.cs
@@ -32,6 +32,6 @@ namespace Pathoschild.Http.Client
         /// <summary>Specify the authentication that will be used with every request.</summary>
         /// <param name="scheme">The scheme to use for authorization. e.g.: "Basic", "Bearer".</param>
         /// <param name="parameter">The credentials containing the authentication information.</param>
-        void AddAuthentication(string scheme, string parameter);
+        void SetAuthentication(string scheme, string parameter);
     }
 }

--- a/Client/IClient.cs
+++ b/Client/IClient.cs
@@ -25,6 +25,11 @@ namespace Pathoschild.Http.Client
         /// <returns>Returns a request builder.</returns>
         IRequest SendAsync(HttpRequestMessage message);
 
+        /// <summary>Specify the authentication that will be used with every request.</summary>
+        /// <param name="scheme">The scheme to use for authorization. e.g.: "Basic", "Bearer".</param>
+        /// <param name="parameter">The credentials containing the authentication information.</param>
+        void AddAuthentication(string scheme, string parameter);
+
         /// <summary>Set the default user agent header.</summary>
         /// <param name="userAgent">The user agent header value.</param>
         void SetUserAgent(string userAgent);

--- a/Client/IClient.cs
+++ b/Client/IClient.cs
@@ -28,10 +28,10 @@ namespace Pathoschild.Http.Client
         /// <summary>Specify the authentication that will be used with every request.</summary>
         /// <param name="scheme">The scheme to use for authorization. e.g.: "Basic", "Bearer".</param>
         /// <param name="parameter">The credentials containing the authentication information.</param>
-        void SetAuthentication(string scheme, string parameter);
+        IClient SetAuthentication(string scheme, string parameter);
 
         /// <summary>Set the default user agent header.</summary>
         /// <param name="userAgent">The user agent header value.</param>
-        void SetUserAgent(string userAgent);
+        IClient SetUserAgent(string userAgent);
     }
 }

--- a/Client/IRequest.cs
+++ b/Client/IRequest.cs
@@ -70,5 +70,10 @@ namespace Pathoschild.Http.Client
         /// <code>await client.PostAsync("api/ideas", idea);</code>
         /// </example>
         TaskAwaiter<IResponse> GetAwaiter();
+
+        /// <summary>Specify the authentication for this request.</summary>
+        /// <param name="scheme">The scheme to use for authorization. e.g.: "Basic", "Bearer".</param>
+        /// <param name="parameter">The credentials containing the authentication information.</param>
+        IRequest WithAuthentication(string scheme, string parameter);
     }
 }

--- a/Client/Internal/Request.cs
+++ b/Client/Internal/Request.cs
@@ -140,6 +140,15 @@ namespace Pathoschild.Http.Client.Internal
             return waiter().GetAwaiter();
         }
 
+        /// <summary>Specify the authentication that will be used with every request.</summary>
+        /// <param name="scheme">The scheme to use for authorization. e.g.: "Basic", "Bearer".</param>
+        /// <param name="parameter">The credentials containing the authentication information.</param>
+        public IRequest WithAuthentication(string scheme, string parameter)
+        {
+            this.Message.Headers.Authorization = new AuthenticationHeaderValue(scheme, parameter);
+            return this;
+        }
+
         /***
         ** Retrieve response
         ***/


### PR DESCRIPTION
Add methods on the IClient and IRequest interfaces that allow developers to specify the authentication scheme they want to use and implement these methods in the FluentClient and the Request classes. Also, add convenient extension methods for some of the most commonly used authentication schemes.

Resolves #10 