### PR TITLE
Ignore null arguments

### DIFF
--- a/Client/FluentClientOptions.cs
+++ b/Client/FluentClientOptions.cs
@@ -1,0 +1,12 @@
+namespace Pathoschild.Http.Client
+{
+    /// <summary>Options for the fluent http client.</summary>
+    public class FluentClientOptions
+    {
+        /// <summary>Indicates whether arguments with null value be ignored when a request is dispatched.</summary>
+        public bool IgnoreNullArguments { get; set; } = true;
+
+        /// <summary>Indicates whether HTTP error responses (e.g. HTTP 404) should be ignored or should be raised as exceptions</summary>
+        public bool IgnoreHttpErrors { get; set; } = false;
+    }
+}

--- a/Client/FluentClientOptions.cs
+++ b/Client/FluentClientOptions.cs
@@ -4,9 +4,18 @@ namespace Pathoschild.Http.Client
     public class FluentClientOptions
     {
         /// <summary>Indicates whether arguments with null value be ignored when a request is dispatched.</summary>
-        public bool IgnoreNullArguments { get; set; } = true;
+        public bool? IgnoreNullArguments { get; set; }
 
         /// <summary>Indicates whether HTTP error responses (e.g. HTTP 404) should be ignored or should be raised as exceptions</summary>
-        public bool IgnoreHttpErrors { get; set; } = false;
+        public bool? IgnoreHttpErrors { get; set; }
+
+        internal RequestOptions ToRequestOptions()
+        {
+            return new RequestOptions()
+            {
+                IgnoreHttpErrors = this.IgnoreHttpErrors,
+                IgnoreNullArguments = this.IgnoreNullArguments
+            };
+        }
     }
 }

--- a/Client/IClient.cs
+++ b/Client/IClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Formatting;
@@ -38,7 +38,12 @@ namespace Pathoschild.Http.Client
 
         /// <summary>Set whether HTTP error responses (e.g. HTTP 404) should be raised as exceptions by default.</summary>
         /// <param name="enabled">Whether to raise HTTP errors as exceptions by default.</param>
+        [Obsolete("Will be removed in version 4. Use `SetOptions` instead.")]
         IClient SetHttpErrorAsException(bool enabled);
+
+        /// <summary>Set default options for all requests.</summary>
+        /// <param name="options">The options.</param>
+        IClient SetOptions(FluentClientOptions options);
 
         /// <summary>Set the default user agent header.</summary>
         /// <param name="userAgent">The user agent header value.</param>

--- a/Client/IRequest.cs
+++ b/Client/IRequest.cs
@@ -84,6 +84,10 @@ namespace Pathoschild.Http.Client
         /// <param name="enabled">Whether to raise HTTP errors as exceptions.</param>
         IRequest WithHttpErrorAsException(bool enabled);
 
+        /// <summary>Set whether aguments with null value should be ignored for this request.</summary>
+        /// <param name="ignoreNullArguments">Whether to ignore arguments with null value.</param>
+        IRequest WithIgnoreNullArguments(bool ignoreNullArguments);
+
         /// <summary>Set the request coordinator for this request.</summary>
         /// <param name="requestCoordinator">The request coordinator (or null to use the default behaviour).</param>
         IRequest WithRequestCoordinator(IRequestCoordinator requestCoordinator);

--- a/Client/IRequest.cs
+++ b/Client/IRequest.cs
@@ -82,11 +82,12 @@ namespace Pathoschild.Http.Client
 
         /// <summary>Set whether HTTP error responses (e.g. HTTP 404) should be raised as exceptions for this request.</summary>
         /// <param name="enabled">Whether to raise HTTP errors as exceptions.</param>
+        [Obsolete("Will be removed in version 4. Use `WithOptions` instead.")]
         IRequest WithHttpErrorAsException(bool enabled);
 
-        /// <summary>Set whether aguments with null value should be ignored for this request.</summary>
-        /// <param name="ignoreNullArguments">Whether to ignore arguments with null value.</param>
-        IRequest WithIgnoreNullArguments(bool ignoreNullArguments);
+        /// <summary>Set options for this request.</summary>
+        /// <param name="options">The options.</param>
+        IRequest WithOptions(RequestOptions options);
 
         /// <summary>Set the request coordinator for this request.</summary>
         /// <param name="requestCoordinator">The request coordinator (or null to use the default behaviour).</param>

--- a/Client/Internal/Request.cs
+++ b/Client/Internal/Request.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -25,6 +25,9 @@ namespace Pathoschild.Http.Client.Internal
 
         /// <summary>Whether HTTP error responses (e.g. HTTP 404) should be raised as exceptions.</summary>
         private bool HttpErrorAsException;
+
+        /// <summary>Whether arguments with null value should be ignored.</summary>
+        private bool IgnoreNullArguments;
 
 
         /*********
@@ -101,7 +104,7 @@ namespace Pathoschild.Http.Client.Internal
         /// <returns>Returns the request builder for chaining.</returns>
         public IRequest WithArgument(string key, object value)
         {
-            this.Message.RequestUri = this.Message.RequestUri.WithArguments(new KeyValuePair<string, object>(key, value));
+            this.Message.RequestUri = this.Message.RequestUri.WithArguments(this.IgnoreNullArguments, new KeyValuePair<string, object>(key, value));
             return this;
         }
 
@@ -120,7 +123,7 @@ namespace Pathoschild.Http.Client.Internal
                 where !string.IsNullOrWhiteSpace(key)
                 select new KeyValuePair<string, object>(key, arg.Value)
             ).ToArray();
-            this.Message.RequestUri = this.Message.RequestUri.WithArguments(args);
+            this.Message.RequestUri = this.Message.RequestUri.WithArguments(this.IgnoreNullArguments, args);
             return this;
         }
 
@@ -139,7 +142,7 @@ namespace Pathoschild.Http.Client.Internal
                 select new KeyValuePair<string, object>(property.Name, property.GetValue(arguments))
             ).ToArray();
 
-            this.Message.RequestUri = this.Message.RequestUri.WithArguments(args);
+            this.Message.RequestUri = this.Message.RequestUri.WithArguments(this.IgnoreNullArguments, args);
             return this;
         }
 
@@ -166,6 +169,14 @@ namespace Pathoschild.Http.Client.Internal
         public IRequest WithHttpErrorAsException(bool enabled)
         {
             this.HttpErrorAsException = enabled;
+            return this;
+        }
+
+        /// <summary>Set whether aguments with null value should be ignored for this request.</summary>
+        /// <param name="ignoreNullArguments">Whether to ignore arguments with null value.</param>
+        public IRequest WithIgnoreNullArguments(bool ignoreNullArguments)
+        {
+            this.IgnoreNullArguments = ignoreNullArguments;
             return this;
         }
 

--- a/Client/Internal/Request.cs
+++ b/Client/Internal/Request.cs
@@ -23,11 +23,12 @@ namespace Pathoschild.Http.Client.Internal
         /// <summary>Dispatcher that executes the request.</summary>
         private readonly Func<IRequest, Task<HttpResponseMessage>> Dispatcher;
 
-        /// <summary>Whether HTTP error responses (e.g. HTTP 404) should be raised as exceptions.</summary>
-        private bool HttpErrorAsException;
-
-        /// <summary>Whether arguments with null value should be ignored.</summary>
-        private bool IgnoreNullArguments;
+        /// <summary>Options for this request.</summary>
+        private RequestOptions Options = new RequestOptions()
+        {
+            IgnoreHttpErrors = false,   // By default, do not ignore errors
+            IgnoreNullArguments = true  // By default, ignore arguments with null value
+        };
 
 
         /*********
@@ -104,7 +105,7 @@ namespace Pathoschild.Http.Client.Internal
         /// <returns>Returns the request builder for chaining.</returns>
         public IRequest WithArgument(string key, object value)
         {
-            this.Message.RequestUri = this.Message.RequestUri.WithArguments(this.IgnoreNullArguments, new KeyValuePair<string, object>(key, value));
+            this.Message.RequestUri = this.Message.RequestUri.WithArguments(this.Options.IgnoreNullArguments.Value, new KeyValuePair<string, object>(key, value));
             return this;
         }
 
@@ -123,7 +124,7 @@ namespace Pathoschild.Http.Client.Internal
                 where !string.IsNullOrWhiteSpace(key)
                 select new KeyValuePair<string, object>(key, arg.Value)
             ).ToArray();
-            this.Message.RequestUri = this.Message.RequestUri.WithArguments(this.IgnoreNullArguments, args);
+            this.Message.RequestUri = this.Message.RequestUri.WithArguments(this.Options.IgnoreNullArguments.Value, args);
             return this;
         }
 
@@ -142,7 +143,7 @@ namespace Pathoschild.Http.Client.Internal
                 select new KeyValuePair<string, object>(property.Name, property.GetValue(arguments))
             ).ToArray();
 
-            this.Message.RequestUri = this.Message.RequestUri.WithArguments(this.IgnoreNullArguments, args);
+            this.Message.RequestUri = this.Message.RequestUri.WithArguments(this.Options.IgnoreNullArguments.Value, args);
             return this;
         }
 
@@ -166,17 +167,20 @@ namespace Pathoschild.Http.Client.Internal
 
         /// <summary>Set whether HTTP errors (e.g. HTTP 500) should be raised an exceptions for this request.</summary>
         /// <param name="enabled">Whether to raise HTTP errors as exceptions.</param>
+        [Obsolete("Will be removed in version 4. Use `WithOptions` instead.")]
         public IRequest WithHttpErrorAsException(bool enabled)
         {
-            this.HttpErrorAsException = enabled;
+            this.Options.IgnoreHttpErrors = !enabled;
             return this;
         }
 
-        /// <summary>Set whether aguments with null value should be ignored for this request.</summary>
-        /// <param name="ignoreNullArguments">Whether to ignore arguments with null value.</param>
-        public IRequest WithIgnoreNullArguments(bool ignoreNullArguments)
+        /// <summary>Set options for this request.</summary>
+        /// <param name="options">The options.</param>
+        public IRequest WithOptions(RequestOptions options)
         {
-            this.IgnoreNullArguments = ignoreNullArguments;
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (options.IgnoreHttpErrors.HasValue) this.Options.IgnoreHttpErrors = options.IgnoreHttpErrors;
+            if (options.IgnoreNullArguments.HasValue) this.Options.IgnoreNullArguments = options.IgnoreNullArguments;
             return this;
         }
 
@@ -280,7 +284,7 @@ namespace Pathoschild.Http.Client.Internal
 
             // apply response filters
             foreach (IHttpFilter filter in this.Filters)
-                filter.OnResponse(response, this.HttpErrorAsException);
+                filter.OnResponse(response, !this.Options.IgnoreHttpErrors.Value);
 
             return response;
         }

--- a/Client/Internal/UriExtensions.cs
+++ b/Client/Internal/UriExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -11,15 +11,27 @@ namespace Pathoschild.Http.Client.Internal
         /// <summary>Add raw arguments to the URI's query string.</summary>
         /// <param name="uri">The URI to extend.</param>
         /// <param name="arguments">The raw arguments to add.</param>
+        /// <param name="ignoreNullArguments">Indicates whether to ignore arguments with null value.</param>
         /// <remarks>This method can't use <see cref="System.Net.Http.UriExtensions.ParseQueryString" /> because it isn't compatible with portable class libraries.</remarks>
-        public static Uri WithArguments(this Uri uri, params KeyValuePair<string, object>[] arguments)
+        public static Uri WithArguments(this Uri uri, bool ignoreNullArguments, params KeyValuePair<string, object>[] arguments)
         {
-            string queryString = string.Join("&",
+            string argumentsWithValue = string.Join("&",
                 from argument in arguments
+                where argument.Value != null
                 let key = WebUtility.UrlEncode(argument.Key)
-                let value = argument.Value != null ? WebUtility.UrlEncode(argument.Value.ToString()) : string.Empty
+                let value = WebUtility.UrlEncode(argument.Value.ToString())
                 select key + "=" + value
             );
+
+            string argumentsWithoutValue = string.Join("&",
+                from argument in arguments
+                where argument.Value == null
+                let key = WebUtility.UrlEncode(argument.Key)
+                select key + "="
+            );
+
+            string queryString = argumentsWithValue + (!ignoreNullArguments && !string.IsNullOrEmpty(argumentsWithoutValue) ? "&" + argumentsWithoutValue : string.Empty);
+
             return new Uri(
                 uri
                 + (string.IsNullOrWhiteSpace(uri.Query) ? "?" : "&")

--- a/Client/Internal/UriExtensions.cs
+++ b/Client/Internal/UriExtensions.cs
@@ -15,22 +15,13 @@ namespace Pathoschild.Http.Client.Internal
         /// <remarks>This method can't use <see cref="System.Net.Http.UriExtensions.ParseQueryString" /> because it isn't compatible with portable class libraries.</remarks>
         public static Uri WithArguments(this Uri uri, bool ignoreNullArguments, params KeyValuePair<string, object>[] arguments)
         {
-            string argumentsWithValue = string.Join("&",
+            string queryString = string.Join("&",
                 from argument in arguments
-                where argument.Value != null
+                where !ignoreNullArguments || argument.Value != null
                 let key = WebUtility.UrlEncode(argument.Key)
-                let value = WebUtility.UrlEncode(argument.Value.ToString())
+                let value = argument.Value != null ? WebUtility.UrlEncode(argument.Value.ToString()) : string.Empty
                 select key + "=" + value
             );
-
-            string argumentsWithoutValue = string.Join("&",
-                from argument in arguments
-                where argument.Value == null
-                let key = WebUtility.UrlEncode(argument.Key)
-                select key + "="
-            );
-
-            string queryString = argumentsWithValue + (!ignoreNullArguments && !string.IsNullOrEmpty(argumentsWithoutValue) ? "&" + argumentsWithoutValue : string.Empty);
 
             return new Uri(
                 uri

--- a/Client/RequestOptions.cs
+++ b/Client/RequestOptions.cs
@@ -1,0 +1,12 @@
+namespace Pathoschild.Http.Client
+{
+    /// <summary>Options for a request.</summary>
+    public class RequestOptions
+    {
+        /// <summary>Indicates whether arguments with null value be ignored when the request is dispatched.</summary>
+        public bool? IgnoreNullArguments { get; set; }
+
+        /// <summary>Indicates whether HTTP error responses (e.g. HTTP 404) should be ignored or should be raised as exceptions</summary>
+        public bool? IgnoreHttpErrors { get; set; }
+    }
+}

--- a/Tests/Client/RequestTests.cs
+++ b/Tests/Client/RequestTests.cs
@@ -221,7 +221,7 @@ namespace Pathoschild.Http.Tests.Client
         [TestCase("GET", "aaa", null, true)]
         [TestCase("GET", null, "bbb", true)]
         [TestCase("GET", "aaa", null, false)]
-        [TestCase("GET", null,"bbb", false)]
+        [TestCase("GET", null, "bbb", false)]
         public void WithArguments_Object_IgnoresArgumentWithNullValue(string methodName, string valueA, string valueB, bool ignoreNullArguments)
         {
             // execute
@@ -606,29 +606,14 @@ namespace Pathoschild.Http.Tests.Client
 
         private void AssertQuerystringArgument(IDictionary<string, StringValues> arguments, string key, string value, bool ignoreNullArguments)
         {
-            if (ignoreNullArguments)
+            if (ignoreNullArguments && value == null)
             {
-                if (value == null)
-                {
-                    Assert.That(arguments.ContainsKey(key), Is.False, $"Argument {key} with null value should have been ignored");
-                }
-                else
-                {
-                    Assert.That(arguments.ContainsKey(key), Is.True, $"Argument {key}  with null value shouldn't have been ignored");
-                    Assert.That(arguments[key], Is.EqualTo(value), $"Argument {key}'s value should be {value}.");
-                }
+                Assert.That(arguments.ContainsKey(key), Is.False, $"Argument {key} with null value should have been ignored");
             }
             else
             {
                 Assert.That(arguments.ContainsKey(key), Is.True, $"Argument {key} with null value shouldn't have been ignored");
-                if (value == null)
-                {
-                    Assert.That(string.IsNullOrEmpty(arguments[key]), Is.True, $"Argument {key}'s value should be null.");
-                }
-                else
-                {
-                    Assert.That(arguments[key], Is.EqualTo(value), $"Argument {key}'s value should be {value}.");
-                }
+                Assert.That(arguments[key], Is.EqualTo(value ?? ""), $"Argument {key}'s value should be '{value}'.");
             }
         }
     }

--- a/Tests/Client/RequestTests.cs
+++ b/Tests/Client/RequestTests.cs
@@ -113,7 +113,7 @@ namespace Pathoschild.Http.Tests.Client
             // execute
             IRequest request = this
                 .ConstructRequest(methodName)
-                .WithIgnoreNullArguments(ignoreNullArguments)
+                .WithOptions(new RequestOptions() { IgnoreNullArguments = ignoreNullArguments })
                 .WithArgument(key, value);
 
             // verify
@@ -202,7 +202,7 @@ namespace Pathoschild.Http.Tests.Client
             // execute
             IRequest request = this
                 .ConstructRequest(methodName)
-                .WithIgnoreNullArguments(ignoreNullArguments)
+                .WithOptions(new RequestOptions() { IgnoreNullArguments = ignoreNullArguments })
                 .WithArguments(new[]
                 {
                     new KeyValuePair<string, object>(keyA, valueA),
@@ -227,7 +227,7 @@ namespace Pathoschild.Http.Tests.Client
             // execute
             IRequest request = this
                 .ConstructRequest(methodName)
-                .WithIgnoreNullArguments(ignoreNullArguments)
+                .WithOptions(new RequestOptions() { IgnoreNullArguments = ignoreNullArguments })
                 .WithArguments(new { keyA = valueA, keyB = valueB });
 
             // verify
@@ -410,8 +410,8 @@ namespace Pathoschild.Http.Tests.Client
             Assert.NotNull(ex.Response, "The HTTP response on the exception is null.");
         }
 
-        [Test(Description = "Ensure that WithHttpErrorAsException can disable HTTP errors as exceptions.")]
-        public async Task WithHttpErrorAsException_DisablesException()
+        [Test(Description = "Ensure that WithOptions can disable HTTP errors as exceptions.")]
+        public async Task WithOptions_DisablesException()
         {
             // arrange
             var mockHttp = new MockHttpMessageHandler();
@@ -419,7 +419,7 @@ namespace Pathoschild.Http.Tests.Client
             var client = new FluentClient("https://example.org", new HttpClient(mockHttp));
 
             // verify
-            IResponse response = await client.GetAsync("/").WithHttpErrorAsException(false);
+            IResponse response = await client.GetAsync("/").WithOptions(new RequestOptions() { IgnoreHttpErrors = true });
             Assert.NotNull(response, "The HTTP response is null.");
             Assert.NotNull(response.Message, "The HTTP response message is null.");
             Assert.AreEqual(HttpStatusCode.NotFound, response.Status, "The HTTP status doesn't match the response.");

--- a/Tests/Client/RetryCoordinatorTests.cs
+++ b/Tests/Client/RetryCoordinatorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -82,7 +82,7 @@ namespace Pathoschild.Http.Tests.Client
                 Assert.AreEqual(1, attempts, "The client unexpectedly retried.");
 
                 // validate response when errors-as-exceptions is disabled
-                IResponse response = await client.GetAsync("").WithHttpErrorAsException(false);
+                IResponse response = await client.GetAsync("").WithOptions(new RequestOptions() { IgnoreHttpErrors = true });
                 Assert.AreEqual(this.TimeoutStatusCode, response.Status, "The response has an unexpected status code.");
             }
         }


### PR DESCRIPTION
Allow developers to specify if they want arguments with null value to be ignored. By default, null arguments are ignored but this value can be overridden at the client level. This value can be further overridden on each request.

Here's how to set this value at the client level:
```csharp
var client = new FluentClient(baseUrl, new FluentClientOptions
{
   IgnoreNullArguments = false
});
```

Here's how to override this setting on a given request:
```csharp
var request = client
    .GetAsync("endpoint")
    .WithIgnoreNullArguments(true)
    .WithArgument("keyA", null)
```

Resolves #73 