### PR TITLE
Add another FluentClient constructor

### DIFF
--- a/Client/FluentClient.cs
+++ b/Client/FluentClient.cs
@@ -88,6 +88,17 @@ namespace Pathoschild.Http.Client
             this.SetDefaultUserAgent();
         }
 
+        /// <summary>Construct an instance.</summary>
+        /// <param name="baseClient">The underlying HTTP client.</param>
+        /// <param name="manageBaseClient">Whether to dispose the <paramref name="baseClient"/> when the instance is disposed.</param>
+        public FluentClient(HttpClient? baseClient, bool manageBaseClient = false)
+        {
+            this.MustDisposeBaseClient = baseClient == null || manageBaseClient;
+            this.BaseClient = baseClient ?? new HttpClient(GetDefaultHandler());
+
+            this.SetDefaultUserAgent();
+        }
+
         /// <summary>Create an asynchronous HTTP request message (but don't dispatch it yet).</summary>
         /// <param name="message">The HTTP request message to send.</param>
         /// <returns>Returns a request builder.</returns>


### PR DESCRIPTION
Added a FluentClient constructor that takes HttpClient and manageBaseClient as arguments. 

I felt this constructor was missing after using other libraries such as RestSharp, this should make it easier when using a pre configured `HttpClient` (ie from `WebApplicationFactory`). Feels better to use than passing null into a contructor and not knowing how it will handle it.

``` C#
var httpClient = _webApplicationFactory.CreateClient();
// Old version
var fluentClient = new FluentClient(null, httpClient);
// New version 
var fluentClient = new FluentClient(httpClient);

// RestSharp version
var restClient = new RestClient(httpClient);
```