### PR TITLE
Remove duplicate code in constructor

### DIFF
--- a/Client/FluentClient.cs
+++ b/Client/FluentClient.cs
@@ -69,10 +69,7 @@ namespace Pathoschild.Http.Client
         /// <param name="baseUri">The base URI prepended to relative request URIs.</param>
         /// <param name="proxy">The web proxy.</param>
         public FluentClient(Uri? baseUri, IWebProxy? proxy)
-            : this(baseUri, new HttpClient(GetDefaultHandler(proxy)), manageBaseClient: true)
-        {
-            this.MustDisposeBaseClient = true;
-        }
+            : this(baseUri, new HttpClient(GetDefaultHandler(proxy)), manageBaseClient: true) { }
 
         /// <summary>Construct an instance.</summary>
         /// <param name="baseUri">The base URI prepended to relative request URIs.</param>

--- a/Client/FluentClient.cs
+++ b/Client/FluentClient.cs
@@ -92,12 +92,7 @@ namespace Pathoschild.Http.Client
         /// <param name="baseClient">The underlying HTTP client.</param>
         /// <param name="manageBaseClient">Whether to dispose the <paramref name="baseClient"/> when the instance is disposed.</param>
         public FluentClient(HttpClient? baseClient, bool manageBaseClient = false)
-        {
-            this.MustDisposeBaseClient = baseClient == null || manageBaseClient;
-            this.BaseClient = baseClient ?? new HttpClient(GetDefaultHandler());
-
-            this.SetDefaultUserAgent();
-        }
+            : this(null, baseClient, manageBaseClient) { }
 
         /// <summary>Create an asynchronous HTTP request message (but don't dispatch it yet).</summary>
         /// <param name="message">The HTTP request message to send.</param>


### PR DESCRIPTION
Following up on [my comment in PR-108](https://github.com/Pathoschild/FluentHttpClient/pull/108#issuecomment-1183381079), I made the follow improvements:
- Removed duplicate code in the new constructor.
- Also, removed a redundant line in a different constructor: the line `this.MustDisposeBaseClient = true;` in the `public FluentClient(Uri? baseUri, IWebProxy? proxy)` constructor made sense when the FluentClient constructor automatically determined if the base http client should be disposed and did not allow this boolean value to be specified in the constructor. However, this line has been made redundant by an [April 2020 update](972dee074f9e3f5b27997dbe81b6c4a8d470184a).
