### PR TITLE
Add/Remove filters per request

### DIFF
--- a/Client/IRequest.cs
+++ b/Client/IRequest.cs
@@ -93,9 +93,9 @@ namespace Pathoschild.Http.Client
         IRequest WithRequestCoordinator(IRequestCoordinator? requestCoordinator);
 
         /// <summary>Add a filter for this request.</summary>
-        /// <typeparam name="T">The type of the filter.</typeparam>
+        /// <typeparam name="TFilter">The type of the filter.</typeparam>
         /// <param name="filter">The filter.</param>
-        IRequest WithFilter<T>(T filter) where T : IHttpFilter;
+        IRequest WithFilter<TFilter>(TFilter filter) where TFilter : IHttpFilter;
 
         /****
         ** Response shortcuts

--- a/Client/IRequest.cs
+++ b/Client/IRequest.cs
@@ -98,6 +98,10 @@ namespace Pathoschild.Http.Client
         /// <param name="removeExisting">Indicates whether existing filters of type TFilter should be removed before adding the filter.</param>
         IRequest WithFilter<TFilter>(TFilter filter, bool removeExisting = true) where TFilter : IHttpFilter;
 
+        /// <summary>Remove filter of matching type from this request.</summary>
+        /// <typeparam name="TFilter">The type of the filter to remove.</typeparam>
+        IRequest WithoutFilter<TFilter>() where TFilter : IHttpFilter;
+
         /****
         ** Response shortcuts
         ****/

--- a/Client/IRequest.cs
+++ b/Client/IRequest.cs
@@ -95,8 +95,7 @@ namespace Pathoschild.Http.Client
         /// <summary>Add a filter for this request.</summary>
         /// <typeparam name="TFilter">The type of the filter.</typeparam>
         /// <param name="filter">The filter.</param>
-        /// <param name="removeExisting">Indicates whether existing filters of type TFilter should be removed before adding the filter.</param>
-        IRequest WithFilter<TFilter>(TFilter filter, bool removeExisting = true) where TFilter : IHttpFilter;
+        IRequest WithFilter<TFilter>(TFilter filter) where TFilter : IHttpFilter;
 
         /// <summary>Remove filter of matching type from this request.</summary>
         /// <typeparam name="TFilter">The type of the filter to remove.</typeparam>

--- a/Client/IRequest.cs
+++ b/Client/IRequest.cs
@@ -92,6 +92,11 @@ namespace Pathoschild.Http.Client
         /// <param name="requestCoordinator">The request coordinator (or null to use the default behaviour).</param>
         IRequest WithRequestCoordinator(IRequestCoordinator? requestCoordinator);
 
+        /// <summary>Add a filter for this request.</summary>
+        /// <typeparam name="T">The type of the filter.</typeparam>
+        /// <param name="filter">The filter.</param>
+        IRequest WithFilter<T>(T filter) where T : IHttpFilter;
+
         /****
         ** Response shortcuts
         ****/

--- a/Client/IRequest.cs
+++ b/Client/IRequest.cs
@@ -95,7 +95,8 @@ namespace Pathoschild.Http.Client
         /// <summary>Add a filter for this request.</summary>
         /// <typeparam name="TFilter">The type of the filter.</typeparam>
         /// <param name="filter">The filter.</param>
-        IRequest WithFilter<TFilter>(TFilter filter) where TFilter : IHttpFilter;
+        /// <param name="removeExisting">Indicates whether existing filters of type TFilter should be removed before adding the filter.</param>
+        IRequest WithFilter<TFilter>(TFilter filter, bool removeExisting = true) where TFilter : IHttpFilter;
 
         /****
         ** Response shortcuts

--- a/Client/Internal/Request.cs
+++ b/Client/Internal/Request.cs
@@ -180,9 +180,8 @@ namespace Pathoschild.Http.Client.Internal
         }
 
         /// <inheritdoc/>
-        public IRequest WithFilter<TFilter>(TFilter filter, bool removeExisting = true) where TFilter : IHttpFilter
+        public IRequest WithFilter<TFilter>(TFilter filter) where TFilter : IHttpFilter
         {
-            if (removeExisting) this.Filters.Remove<TFilter>();
             this.Filters.Add(filter);
             return this;
         }

--- a/Client/Internal/Request.cs
+++ b/Client/Internal/Request.cs
@@ -187,6 +187,13 @@ namespace Pathoschild.Http.Client.Internal
             return this;
         }
 
+        /// <inheritdoc/>
+        public IRequest WithoutFilter<TFilter>() where TFilter : IHttpFilter
+        {
+            this.Filters.Remove<TFilter>();
+            return this;
+        }
+
         /***
         ** Retrieve response
         ***/

--- a/Client/Internal/Request.cs
+++ b/Client/Internal/Request.cs
@@ -179,6 +179,14 @@ namespace Pathoschild.Http.Client.Internal
             return this;
         }
 
+        /// <inheritdoc/>
+        public IRequest WithFilter<T>(T filter) where T : IHttpFilter
+        {
+            this.Filters.Remove<T>();
+            this.Filters.Add(filter);
+            return this;
+        }
+
         /***
         ** Retrieve response
         ***/

--- a/Client/Internal/Request.cs
+++ b/Client/Internal/Request.cs
@@ -180,9 +180,9 @@ namespace Pathoschild.Http.Client.Internal
         }
 
         /// <inheritdoc/>
-        public IRequest WithFilter<T>(T filter) where T : IHttpFilter
+        public IRequest WithFilter<TFilter>(TFilter filter) where TFilter : IHttpFilter
         {
-            this.Filters.Remove<T>();
+            this.Filters.Remove<TFilter>();
             this.Filters.Add(filter);
             return this;
         }

--- a/Client/Internal/Request.cs
+++ b/Client/Internal/Request.cs
@@ -180,9 +180,9 @@ namespace Pathoschild.Http.Client.Internal
         }
 
         /// <inheritdoc/>
-        public IRequest WithFilter<TFilter>(TFilter filter) where TFilter : IHttpFilter
+        public IRequest WithFilter<TFilter>(TFilter filter, bool removeExisting = true) where TFilter : IHttpFilter
         {
-            this.Filters.Remove<TFilter>();
+            if (removeExisting) this.Filters.Remove<TFilter>();
             this.Filters.Add(filter);
             return this;
         }


### PR DESCRIPTION
Add fluent methods to add a filter to a request or remove a filter from the request as discussed [here](https://github.com/Pathoschild/FluentHttpClient/issues/110#issuecomment-1209702098).

When adding a filter, developers can specify whether they want filters of matching type to be removed from the request before adding the new filter.