### PR TITLE
Add cancellation token to response, message cloning, and retry delays

### DIFF
--- a/Client/FluentClient.cs
+++ b/Client/FluentClient.cs
@@ -170,7 +170,7 @@ namespace Pathoschild.Http.Client
             this.AssertNotDisposed();
 
             // clone request (to avoid issues when resending messages)
-            HttpRequestMessage requestMessage = await request.Message.CloneAsync().ConfigureAwait(false);
+            HttpRequestMessage requestMessage = await request.Message.CloneAsync(request.CancellationToken).ConfigureAwait(false);
 
             // dispatch request
             return await this.BaseClient

--- a/Client/FluentClientExtensions.cs
+++ b/Client/FluentClientExtensions.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Pathoschild.Http.Client.Extensibility;
 using Pathoschild.Http.Client.Internal;
@@ -286,12 +287,13 @@ namespace Pathoschild.Http.Client
         *********/
         /// <summary>Get a copy of the request.</summary>
         /// <param name="request">The request to copy.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <remarks>Note that cloning a request isn't possible after it's dispatched, because the content stream is automatically disposed after the request.</remarks>
-        internal static async Task<HttpRequestMessage> CloneAsync(this HttpRequestMessage request)
+        internal static async Task<HttpRequestMessage> CloneAsync(this HttpRequestMessage request, CancellationToken cancellationToken = default)
         {
             HttpRequestMessage clone = new HttpRequestMessage(request.Method, request.RequestUri)
             {
-                Content = await request.Content.CloneAsync().ConfigureAwait(false),
+                Content = await request.Content.CloneAsync(cancellationToken).ConfigureAwait(false),
                 Version = request.Version
             };
 
@@ -305,14 +307,15 @@ namespace Pathoschild.Http.Client
 
         /// <summary>Get a copy of the request content.</summary>
         /// <param name="content">The content to copy.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <remarks>Note that cloning content isn't possible after it's dispatched, because the stream is automatically disposed after the request.</remarks>
-        internal static async Task<HttpContent?> CloneAsync(this HttpContent? content)
+        internal static async Task<HttpContent?> CloneAsync(this HttpContent? content, CancellationToken cancellationToken = default)
         {
             if (content == null)
                 return null;
 
             Stream stream = new MemoryStream();
-            await content.CopyToAsync(stream).ConfigureAwait(false);
+            await content.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
             stream.Position = 0;
 
             StreamContent clone = new StreamContent(stream);

--- a/Client/IResponse.cs
+++ b/Client/IResponse.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Formatting;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
@@ -31,36 +32,44 @@ namespace Pathoschild.Http.Client
         *********/
         /// <summary>Asynchronously retrieve the response body as a deserialized model.</summary>
         /// <typeparam name="T">The response model to deserialize into.</typeparam>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<T> As<T>();
+        Task<T> As<T>(CancellationToken cancellationToken = default);
 
         /// <summary>Asynchronously retrieve the response body as a list of deserialized models.</summary>
         /// <typeparam name="T">The response model to deserialize into.</typeparam>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<T[]> AsArray<T>();
+        Task<T[]> AsArray<T>(CancellationToken cancellationToken = default);
 
         /// <summary>Asynchronously retrieve the response body as an array of <see cref="byte"/>.</summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<byte[]> AsByteArray();
+        Task<byte[]> AsByteArray(CancellationToken cancellationToken = default);
 
         /// <summary>Asynchronously retrieve the response body as a <see cref="string"/>.</summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<string> AsString();
+        Task<string> AsString(CancellationToken cancellationToken = default);
 
         /// <summary>Asynchronously retrieve the response body as a <see cref="Stream"/>.</summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<Stream> AsStream();
+        Task<Stream> AsStream(CancellationToken cancellationToken = default);
 
         /// <summary>Get a raw JSON representation of the response, which can also be accessed as a <c>dynamic</c> value.</summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<JToken> AsRawJson();
+        Task<JToken> AsRawJson(CancellationToken cancellationToken = default);
 
         /// <summary>Get a raw JSON object representation of the response, which can also be accessed as a <c>dynamic</c> value.</summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<JObject> AsRawJsonObject();
+        Task<JObject> AsRawJsonObject(CancellationToken cancellationToken = default);
 
         /// <summary>Get a raw JSON array representation of the response, which can also be accessed as a <c>dynamic</c> value.</summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<JArray> AsRawJsonArray();
+        Task<JArray> AsRawJsonArray(CancellationToken cancellationToken = default);
     }
 }

--- a/Client/IResponse.cs
+++ b/Client/IResponse.cs
@@ -26,50 +26,51 @@ namespace Pathoschild.Http.Client
         /// <summary>The formatters used for serializing and deserializing message bodies.</summary>
         MediaTypeFormatterCollection Formatters { get; }
 
+        /// <summary>The optional token used to cancel async operations.</summary>
+        CancellationToken CancellationToken { get; }
+
 
         /*********
         ** Methods
         *********/
+
+        /// <summary>Specify the token that can be used to cancel the async operation.</summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Returns the response builder for chaining.</returns>
+        IResponse WithCancellationToken(CancellationToken cancellationToken);
+
         /// <summary>Asynchronously retrieve the response body as a deserialized model.</summary>
         /// <typeparam name="T">The response model to deserialize into.</typeparam>
-        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<T> As<T>(CancellationToken cancellationToken = default);
+        Task<T> As<T>();
 
         /// <summary>Asynchronously retrieve the response body as a list of deserialized models.</summary>
         /// <typeparam name="T">The response model to deserialize into.</typeparam>
-        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<T[]> AsArray<T>(CancellationToken cancellationToken = default);
+        Task<T[]> AsArray<T>();
 
         /// <summary>Asynchronously retrieve the response body as an array of <see cref="byte"/>.</summary>
-        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<byte[]> AsByteArray(CancellationToken cancellationToken = default);
+        Task<byte[]> AsByteArray();
 
         /// <summary>Asynchronously retrieve the response body as a <see cref="string"/>.</summary>
-        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<string> AsString(CancellationToken cancellationToken = default);
+        Task<string> AsString();
 
         /// <summary>Asynchronously retrieve the response body as a <see cref="Stream"/>.</summary>
-        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<Stream> AsStream(CancellationToken cancellationToken = default);
+        Task<Stream> AsStream();
 
         /// <summary>Get a raw JSON representation of the response, which can also be accessed as a <c>dynamic</c> value.</summary>
-        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<JToken> AsRawJson(CancellationToken cancellationToken = default);
+        Task<JToken> AsRawJson();
 
         /// <summary>Get a raw JSON object representation of the response, which can also be accessed as a <c>dynamic</c> value.</summary>
-        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<JObject> AsRawJsonObject(CancellationToken cancellationToken = default);
+        Task<JObject> AsRawJsonObject();
 
         /// <summary>Get a raw JSON array representation of the response, which can also be accessed as a <c>dynamic</c> value.</summary>
-        /// <param name="cancellationToken">The cancellation token.</param>
         /// <exception cref="ApiException">An error occurred processing the response.</exception>
-        Task<JArray> AsRawJsonArray(CancellationToken cancellationToken = default);
+        Task<JArray> AsRawJsonArray();
     }
 }

--- a/Client/Internal/Request.cs
+++ b/Client/Internal/Request.cs
@@ -206,7 +206,7 @@ namespace Pathoschild.Http.Client.Internal
         public async Task<T> As<T>()
         {
             IResponse response = await this.AsResponse().ConfigureAwait(false);
-            return await response.As<T>(this.CancellationToken).ConfigureAwait(false);
+            return await response.As<T>().ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -219,42 +219,42 @@ namespace Pathoschild.Http.Client.Internal
         public async Task<byte[]> AsByteArray()
         {
             IResponse response = await this.AsResponse().ConfigureAwait(false);
-            return await response.AsByteArray(this.CancellationToken).ConfigureAwait(false);
+            return await response.AsByteArray().ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<string> AsString()
         {
             IResponse response = await this.AsResponse().ConfigureAwait(false);
-            return await response.AsString(this.CancellationToken).ConfigureAwait(false);
+            return await response.AsString().ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<Stream> AsStream()
         {
             IResponse response = await this.AsResponse().ConfigureAwait(false);
-            return await response.AsStream(this.CancellationToken).ConfigureAwait(false);
+            return await response.AsStream().ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<JToken> AsRawJson()
         {
             IResponse response = await this.AsResponse().ConfigureAwait(false);
-            return await response.AsRawJson(this.CancellationToken).ConfigureAwait(false);
+            return await response.AsRawJson().ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<JObject> AsRawJsonObject()
         {
             IResponse response = await this.AsResponse().ConfigureAwait(false);
-            return await response.AsRawJsonObject(this.CancellationToken).ConfigureAwait(false);
+            return await response.AsRawJsonObject().ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<JArray> AsRawJsonArray()
         {
             IResponse response = await this.AsResponse().ConfigureAwait(false);
-            return await response.AsRawJsonArray(this.CancellationToken).ConfigureAwait(false);
+            return await response.AsRawJsonArray().ConfigureAwait(false);
         }
 
 
@@ -272,7 +272,7 @@ namespace Pathoschild.Http.Client.Internal
             HttpResponseMessage responseMessage = this.RequestCoordinator != null
                 ? await this.RequestCoordinator.ExecuteAsync(this, this.Dispatcher).ConfigureAwait(false)
                 : await this.Dispatcher(this).ConfigureAwait(false);
-            IResponse response = new Response(responseMessage, this.Formatters);
+            IResponse response = new Response(responseMessage, this.Formatters, this.CancellationToken);
 
             // apply response filters
             foreach (IHttpFilter filter in this.Filters)

--- a/Client/Internal/Request.cs
+++ b/Client/Internal/Request.cs
@@ -206,7 +206,7 @@ namespace Pathoschild.Http.Client.Internal
         public async Task<T> As<T>()
         {
             IResponse response = await this.AsResponse().ConfigureAwait(false);
-            return await response.As<T>().ConfigureAwait(false);
+            return await response.As<T>(this.CancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -219,42 +219,42 @@ namespace Pathoschild.Http.Client.Internal
         public async Task<byte[]> AsByteArray()
         {
             IResponse response = await this.AsResponse().ConfigureAwait(false);
-            return await response.AsByteArray().ConfigureAwait(false);
+            return await response.AsByteArray(this.CancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<string> AsString()
         {
             IResponse response = await this.AsResponse().ConfigureAwait(false);
-            return await response.AsString().ConfigureAwait(false);
+            return await response.AsString(this.CancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<Stream> AsStream()
         {
             IResponse response = await this.AsResponse().ConfigureAwait(false);
-            return await response.AsStream().ConfigureAwait(false);
+            return await response.AsStream(this.CancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<JToken> AsRawJson()
         {
             IResponse response = await this.AsResponse().ConfigureAwait(false);
-            return await response.AsRawJson().ConfigureAwait(false);
+            return await response.AsRawJson(this.CancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<JObject> AsRawJsonObject()
         {
             IResponse response = await this.AsResponse().ConfigureAwait(false);
-            return await response.AsRawJsonObject().ConfigureAwait(false);
+            return await response.AsRawJsonObject(this.CancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task<JArray> AsRawJsonArray()
         {
             IResponse response = await this.AsResponse().ConfigureAwait(false);
-            return await response.AsRawJsonArray().ConfigureAwait(false);
+            return await response.AsRawJsonArray(this.CancellationToken).ConfigureAwait(false);
         }
 
 

--- a/Client/Internal/Response.cs
+++ b/Client/Internal/Response.cs
@@ -55,7 +55,7 @@ namespace Pathoschild.Http.Client.Internal
         /// <inheritdoc />
         public Task<T> As<T>()
         {
-            return this.Message.Content.ReadAsAsync<T>(this.Formatters);
+            return this.Message.Content.ReadAsAsync<T>(this.Formatters, this.CancellationToken);
         }
 
         /// <inheritdoc />

--- a/Client/Internal/Response.cs
+++ b/Client/Internal/Response.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Formatting;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
@@ -40,55 +41,55 @@ namespace Pathoschild.Http.Client.Internal
         }
 
         /// <inheritdoc />
-        public Task<T> As<T>()
+        public Task<T> As<T>(CancellationToken cancellationToken = default)
         {
-            return this.Message.Content.ReadAsAsync<T>(this.Formatters);
+            return this.Message.Content.ReadAsAsync<T>(this.Formatters, cancellationToken);
         }
 
         /// <inheritdoc />
-        public Task<T[]> AsArray<T>()
+        public Task<T[]> AsArray<T>(CancellationToken cancellationToken = default)
         {
-            return this.As<T[]>();
+            return this.As<T[]>(cancellationToken);
         }
 
         /// <inheritdoc />
-        public Task<byte[]> AsByteArray()
+        public Task<byte[]> AsByteArray(CancellationToken cancellationToken = default)
         {
-            return this.AssertContent().ReadAsByteArrayAsync();
+            return this.AssertContent().ReadAsByteArrayAsync(cancellationToken);
         }
 
         /// <inheritdoc />
-        public Task<string> AsString()
+        public Task<string> AsString(CancellationToken cancellationToken = default)
         {
-            return this.AssertContent().ReadAsStringAsync();
+            return this.AssertContent().ReadAsStringAsync(cancellationToken);
         }
 
         /// <inheritdoc />
-        public async Task<Stream> AsStream()
+        public async Task<Stream> AsStream(CancellationToken cancellationToken = default)
         {
-            Stream stream = await this.AssertContent().ReadAsStreamAsync().ConfigureAwait(false);
+            Stream stream = await this.AssertContent().ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             stream.Position = 0;
             return stream;
         }
 
         /// <inheritdoc />
-        public async Task<JToken> AsRawJson()
+        public async Task<JToken> AsRawJson(CancellationToken cancellationToken = default)
         {
-            string content = await this.AsString();
+            string content = await this.AsString(cancellationToken);
             return JToken.Parse(content);
         }
 
         /// <inheritdoc />
-        public async Task<JObject> AsRawJsonObject()
+        public async Task<JObject> AsRawJsonObject(CancellationToken cancellationToken = default)
         {
-            string content = await this.AsString();
+            string content = await this.AsString(cancellationToken);
             return JObject.Parse(content);
         }
 
         /// <inheritdoc />
-        public async Task<JArray> AsRawJsonArray()
+        public async Task<JArray> AsRawJsonArray(CancellationToken cancellationToken = default)
         {
-            string content = await this.AsString();
+            string content = await this.AsString(cancellationToken);
             return JArray.Parse(content);
         }
 

--- a/Client/Retry/RetryCoordinator.cs
+++ b/Client/Retry/RetryCoordinator.cs
@@ -99,7 +99,7 @@ namespace Pathoschild.Http.Client.Retry
                 // set up retry
                 TimeSpan delay = retryConfig.GetDelay(attempt, response);
                 if (delay.TotalMilliseconds > 0)
-                    await Task.Delay(delay).ConfigureAwait(false);
+                    await Task.Delay(delay, request.CancellationToken).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
Here are the changes I propose to ensure the cancellation token is always propagated when an async method is invoked.

Resolves #113 