### PR TITLE
Fix absolute paths on unix

### DIFF
--- a/Client/FluentClientExtensions.cs
+++ b/Client/FluentClientExtensions.cs
@@ -350,7 +350,7 @@ namespace Pathoschild.Http.Client
             // ignore if empty or already absolute
             if (string.IsNullOrWhiteSpace(resource))
                 return baseUrl;
-            if (Uri.TryCreate(resource, UriKind.Absolute, out Uri? absoluteUrl))
+            if (Uri.TryCreate(resource, UriKind.Absolute, out Uri? absoluteUrl) && (absoluteUrl.Scheme == "http" || absoluteUrl.Scheme == "https"))
                 return absoluteUrl;
 
             // can't combine if no base URL

--- a/Client/FluentClientExtensions.cs
+++ b/Client/FluentClientExtensions.cs
@@ -350,7 +350,7 @@ namespace Pathoschild.Http.Client
             // ignore if empty or already absolute
             if (string.IsNullOrWhiteSpace(resource))
                 return baseUrl;
-            if (Uri.TryCreate(resource, UriKind.Absolute, out Uri? absoluteUrl) && (absoluteUrl.Scheme == "http" || absoluteUrl.Scheme == "https"))
+            if (Uri.TryCreate(resource, UriKind.Absolute, out Uri? absoluteUrl) && !absoluteUrl.IsFile)
                 return absoluteUrl;
 
             // can't combine if no base URL


### PR DESCRIPTION
I just spent 6 hours trying to figure out why my tests were working fine on my machine, but not when running in the  build pipeline. 

Finally, I managed to figure out it was due to this library behaving differently on Windows vs Linux/Mac. Or rather, you are using a feature of .NET that behaves differently.

I love this library, and I don't want others to experience the same as me, so I hope you will consider this PR. 😄 

# Reproduction

You actually already have unit tests that catch this error. Simply running the tests on Linux/Mac will show the error:

```
Failed Send_WithBaseUrl("PUT","http://example.org","/resources/test") [< 1 ms]
Error Message:
   Expected string length 33 but was 22. Strings differ at index 0.
Expected: "http://example.org/resources/test"
But was:  "file:///resources/test"
```

# Explanation

The error is related to this code:

```csharp
if (Uri.TryCreate(resource, UriKind.Absolute, out Uri? absoluteUrl))
  return absoluteUrl;
```

On Windows, if you provide the path `/resources/test`, it will return false - it is not an absolute url.

But on Linux/Mac, it is an absolute path to a file, so it will return true. 
And the absolute url will be `file:///resources/test`

That means code like this will work on Windows but fail on Linux:

```csharp
var baseClient = new HttpClient();
baseClient.BaseAddress = new Uri("https://localhost:3000/");
var client = new FluentClient(baseClient);
var result = await client.GetAsync("/test").AsString();
```

# Fix

There is [a discussion](https://github.com/dotnet/runtime/issues/22718#issuecomment-314480147) where they mention that using `UriKind.RelativeOrAbsolute` disables the logic of detecting Linux/Mac paths. So, this actually works:

```csharp
if (Uri.TryCreate(resource, UriKind.RelativeOrAbsolute, out Uri? absoluteUrl) 
    && absoluteUrl.IsAbsoluteUri)
  return absoluteUrl;
```

We could also check if the url was http(s):
```csharp
if (Uri.TryCreate(resource, UriKind.Absolute, out Uri? absoluteUrl) 
    && (absoluteUrl.Scheme == "http" || absoluteUrl.Scheme == "https"))
  return absoluteUrl;
```

Or, as I have suggested in this PR, we can check that it is not a file:

```csharp
if (Uri.TryCreate(resource, UriKind.Absolute, out Uri? absoluteUrl) 
    && !absoluteUrl.IsFile)
  return absoluteUrl;
```

Whatever you prefer, it's up to you.
